### PR TITLE
# 인프런 김영한 spring 기초 공부

### DIFF
--- a/src/main/java/com/example/Impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/Impl/MemberServiceImpl.java
@@ -6,7 +6,11 @@ import com.example.role.MemberService;
 
 public class MemberServiceImpl implements MemberService {
 
-    private MemberRepository memberRepository = new MemoryMemberRepositoryImpl();
+    private MemberRepository memberRepository;
+
+    public MemberServiceImpl(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
     @Override
     public void join(Member member) {

--- a/src/main/java/com/example/Impl/OrderServiceImpl.java
+++ b/src/main/java/com/example/Impl/OrderServiceImpl.java
@@ -8,13 +8,13 @@ import com.example.role.OrderService;
 
 public class OrderServiceImpl implements OrderService {
 
-    private MemberRepository memberRepository = new MemoryMemberRepositoryImpl();
+    private MemberRepository memberRepository;
+    private DiscountPolicy discountPolicy;
 
-    /*
-        아래와 같이 코드 짰을떄 OCP 위반, DIP 위반
-     */
-    //private DiscountPolicy discountPolicy = new FixDiscountPolicy();
-    private DiscountPolicy discountPolicy = new PercentDiscountPolicy();
+    public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
+        this.memberRepository = memberRepository;
+        this.discountPolicy = discountPolicy;
+    }
 
     @Override
     public Order createOrder(Member member, String itemName, int itemPrice) {

--- a/src/main/java/com/example/config/AppConfig.java
+++ b/src/main/java/com/example/config/AppConfig.java
@@ -1,0 +1,31 @@
+package com.example.config;
+
+import com.example.Impl.FixDiscountPolicy;
+import com.example.Impl.MemberServiceImpl;
+import com.example.Impl.MemoryMemberRepositoryImpl;
+import com.example.Impl.OrderServiceImpl;
+import com.example.role.DiscountPolicy;
+import com.example.role.MemberRepository;
+import com.example.role.MemberService;
+import com.example.role.OrderService;
+
+public class AppConfig {
+
+    /*
+      해당 인터페이스(MemberService) 에 해당하는 구현체(MemberServiceImpl)에 해당하는 인자까지 생성자 주입을 한다.
+      이런식으로 설계 하면 실제 MemberServiceImpl에 MemberRepository 인터페이스에 직접 구현체를 선언할 필요 없게된다.
+      즉 역할에만 집중할 수 있게 되고 구현은 생각하지 않아도 되게 된다. 실행에만 집중하면 된다.
+      순수 구현체의 선정은 AppConfig가 해주기 때문이다.
+      추후에 구현체가 변경된다고 하더라도 AppConfig에서 구현체만 다른것으로 교체해주면 되기 때문에 OCP 원칙과 DIP 원칙에 위배되지 않는다.
+
+      이러한 것을 생성자 주입이라고 한다.
+     */
+    public MemberService memberService() {
+        return new MemberServiceImpl(new MemoryMemberRepositoryImpl());
+    }
+
+    public OrderService orderService() {
+        return new OrderServiceImpl(new MemoryMemberRepositoryImpl(), new FixDiscountPolicy());
+    }
+
+}

--- a/src/main/java/com/example/springprac/SpringpracApplication.java
+++ b/src/main/java/com/example/springprac/SpringpracApplication.java
@@ -1,5 +1,8 @@
 package com.example.springprac;
 
+import com.example.config.AppConfig;
+import com.example.role.MemberService;
+import com.example.role.OrderService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +10,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SpringpracApplication {
 
     public static void main(String[] args) {
+
+        AppConfig appConfig = new AppConfig();
+        /*
+           앱구동시 생성자 주입!
+         */
+        MemberService memberService = appConfig.memberService();
+        OrderService orderService = appConfig.orderService();
+
         SpringApplication.run(SpringpracApplication.class, args);
     }
 

--- a/src/test/java/com/example/springprac/MemberAppTest.java
+++ b/src/test/java/com/example/springprac/MemberAppTest.java
@@ -3,12 +3,15 @@ package com.example.springprac;
 import com.example.Impl.FixDiscountPolicy;
 import com.example.Impl.MemberServiceImpl;
 import com.example.Impl.OrderServiceImpl;
+import com.example.config.AppConfig;
 import com.example.dto.Member;
 import com.example.dto.Order;
 import com.example.meta.Grade;
 import com.example.role.DiscountPolicy;
 import com.example.role.MemberService;
 import com.example.role.OrderService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,15 +26,26 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class MemberAppTest {
 
-    MemberService memberService = new MemberServiceImpl();
-    OrderService orderService = new OrderServiceImpl();
-    DiscountPolicy discountPolicy = new FixDiscountPolicy();
+    MemberService memberService;
+    OrderService orderService;
+    DiscountPolicy discountPolicy;
+
+    @BeforeEach
+    public void testConfig() {
+
+        /*
+            생성자 주입(구현체 주입)
+         */
+        AppConfig appConfig = new AppConfig();
+        memberService = appConfig.memberService();
+        orderService = appConfig.orderService();
+        discountPolicy = new FixDiscountPolicy();
+    }
 
     @Test
     @DisplayName("멤버 테스트 app 구동 테스트")
     public void memberApp() {
 
-        MemberService memberService = new MemberServiceImpl();
         Member member = new Member(1L,"skydrive860@gmail.com", Grade.normal);
         memberService.join(member);
 
@@ -44,8 +58,6 @@ public class MemberAppTest {
     @Test
     @DisplayName("오더 기능 app 구동 Mocking테스트")
     public void OrderAppMockingTest(@Mock OrderService orderService) {
-
-        MemberService memberService = new MemberServiceImpl();
 
         memberService.join(new Member(1L,"skydrive860@gmail.com",Grade.vip));
 
@@ -61,7 +73,6 @@ public class MemberAppTest {
         assertEquals(9000, orderRes.calculateDiscountPrice());
 
     }
-
 
     public Order createOrderTest(Member member, String itemName, int itemPrice) {
 


### PR DESCRIPTION
- OCP,DIP 위반 해결하기
- AppConfig 객체를 만들어서 구현체를 넣어주는 전문을 하는 설정 객체를 만든다.
- AppConfig를 통해 MemberServiceImpl,OrderServiceImpl 객체들이 순수하게 역할(인터페이스)에만 의존 할수 있도록 코드가 변경된다.
(구체적으로는 인터페이스에서 new 를 통한 구현체 명시를 제거한다)
- 이와 같은 구성일때 구현에 의존적이지 않으며 확장에는 열려있고 변경에는 닫혀 있으므로 순수하게 Impl객체들은 역할에만 의존할 수 있게 된다.

참고해라
@skydrive888 